### PR TITLE
Migrate to ESLint 9, Vitest 4 and improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The noVNC can be accessed at:
 Run the following commands inside the Docker containers:
 
 ```sh
-node examples/redirectChain.mjs
+node examples/get-title.mjs
 ```
 
 You can check if you have enough memory by running this command:

--- a/examples/get-title.mjs
+++ b/examples/get-title.mjs
@@ -1,0 +1,21 @@
+// Googleに接続してページタイトルを取得するサンプル
+import puppeteer from 'puppeteer';
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: [
+      '--disable-gpu',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+    ],
+  });
+
+  const page = await browser.newPage();
+  await page.goto('https://www.google.com');
+
+  const title = await page.title();
+  console.log('Page title:', title);
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary

- Migrate ESLint 8 → 9 with flat config to fix deprecation warnings
- Upgrade Vitest 2.1.6 → 4.0.14 to fix critical security vulnerability
- Add stable get-title.mjs example and update README
- Various Docker and example improvements

## Changes

### ESLint Migration
- Replace `.eslintrc.cjs` with `eslint.config.mjs` (flat config)
- Replace `eslint-config-airbnb-base` with `@eslint/js` + `eslint-plugin-import`
- Remove obsolete eslint-disable comments from example files

### Security Fixes
- Resolve 6 npm deprecation warnings (ESLint 8 and dependencies)
- Resolve 6 security vulnerabilities (Vitest critical RCE, etc.)

### Example Improvements
- Add `examples/get-title.mjs` - stable example using Google
- Update README to use new example instead of httpbin.org (often down)
- Add sandbox flags for container compatibility

## Test plan

- [x] `npm ci` shows no warnings or vulnerabilities
- [x] `npx eslint .` passes with no errors
- [x] `npm test` passes
- [x] `node examples/get-title.mjs` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)