### PR TITLE
Add chromium-sandbox package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ RUN INSTALLYARNUSINGAPT=false \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       chromium \
+      chromium-sandbox \
       fonts-ipafont-gothic \
       fonts-wqy-zenhei \
       fonts-thai-tlwg \


### PR DESCRIPTION
## Summary
- Install `chromium-sandbox` package in Dockerfile to enable sandbox mode for Chromium
- Improves security when running Puppeteer in the Docker container

## Test plan
- [ ] Build Docker image with updated Dockerfile
- [ ] Verify Puppeteer can run with sandbox mode enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)